### PR TITLE
Fix non stop action when no annotations

### DIFF
--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -22,10 +22,14 @@ class GithubCheckRunService
     @conclusion = @report_adapter.conslusion(@report)
 
     result = {}
-    @annotations.each_slice(MAX_ANNOTATIONS_SIZE) do |annotation|
-      result.merge(client_patch_annotations(id, annotation))
-      # Don't need to merge twice
-      client_post_pull_requests(annotation[0])
+    if @annotations.empty?
+      client_patch_annotations(id, [])
+    else
+      @annotations.each_slice(MAX_ANNOTATIONS_SIZE) do |annotation|
+        result.merge(client_patch_annotations(id, annotation))
+        # Don't need to merge twice
+        client_post_pull_requests(annotation[0])
+      end
     end
     result
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

bug fix

## Description

When Brakeman runs successfully without annotations, the check run status won't be updated and will be stuck at in_progress state.

## Why should this be added

The check run status stuck at in_progress is confusing.

## Checklist

- [x] Actions are passing
