### PR TITLE
#3 - Handle brakeman errors outside the PR

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
 
 jobs:
   brakeman:

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - edited
 
 jobs:
   brakeman:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - edited
 
 permissions:
   contents: read

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
 
 jobs:
   rubocop:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - edited
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -44,6 +44,8 @@ class GithubCheckRunService
         pull_request_endpoint_url.to_s,
         create_pull_request_comment_payload(annotation)
       )
+    rescue GithubClient::IssueExistsOutsideOfPullRequestError => e
+      puts "⚠️ Brakeman has detected an issue elsewhere, outside of the Pull Request ⚠️"
     end
 
     def annotation_endpoint_url

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -44,7 +44,7 @@ class GithubCheckRunService
         pull_request_endpoint_url.to_s,
         create_pull_request_comment_payload(annotation)
       )
-    rescue GithubClient::IssueExistsOutsideOfPullRequestError => e
+    rescue GithubClient::IssueExistsOutsideOfPullRequestError
       client_post_pull_request_for_issue_outside_of_pr(annotation)
     end
 
@@ -129,17 +129,13 @@ class GithubCheckRunService
     def pr_comment_body_generator(annotation)
       title = annotation["title"]
       emoji = confidence_level_map(title)
-      body = ("#{emoji} **Potential Vulnerability Detected Outside Of PR** #{emoji}<br /><br />" +
-        "You might not need to deal with this, but be aware that it exists in the codebase.<br />" +
-        "**Confidence level**: #{get_confidence_level(title)}<br />" +
-        "**Type**: #{get_potential_vuln_type(title)}<br />" +
-        "**Description**: #{annotation['message']}<br />" +
-        "**More information available at**: #{BRAKEMAN_URL}<br />" +
-        "**Location**: #{annotation["path"]}:#{annotation["start_line"]}<br />")
-        if @github_data[:custom_message_content]
-          body + @github_data[:custom_message_content]
-        else
-          body
-        end
+      # rubocop:disable Layout/LineLength
+      body = "#{emoji} **Potential Vulnerability Detected Outside Of PR** #{emoji}<br /><br />You might not need to deal with this, but be aware that it exists in the codebase.<br />**Confidence level**: #{get_confidence_level(title)}<br />**Type**: #{get_potential_vuln_type(title)}<br />**Description**: #{annotation['message']}<br />**More information available at**: #{BRAKEMAN_URL}<br />**Location**: #{annotation['path']}:#{annotation['start_line']}<br />"
+      # rubocop:enable Layout/LineLength
+      if @github_data[:custom_message_content]
+        body + @github_data[:custom_message_content]
+      else
+        body
+      end
     end
 end

--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class GithubClient
+  class IssueExistsOutsideOfPullRequestError < StandardError
+  end
+
   def initialize(github_token, user_agent: "ruby")
     @github_token = github_token
     @user_agent = user_agent
@@ -33,6 +36,7 @@ class GithubClient
       http = Net::HTTP.new("api.github.com", 443)
       http.use_ssl = true
       response = yield(http)
+      raise IssueExistsOutsideOfPullRequestError if response.body.include? "pull_request_review_thread.diff_hunk"
       raise "#{response.message}: #{response.body}" if response.code.to_i >= 300
 
       JSON.parse(response.body)

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -64,9 +64,8 @@ describe GithubCheckRunService do
   # Eventually we'll have this comment, but for now, we don't want to fail the build
   context "an issue in the codebase but not in the PR" do
     it "does not fail the build" do
-      comment_text = "⚠️ **Potential Vulnerability Detected Outside Of PR** ⚠️<br /><br />You might not need to deal with this, but be aware that it exists in the codebase.<br />**Confidence level**: Medium<br />**Type**: Deserialize<br />**Description**: `Marshal.load` called with parameter value<br />**More information available at**: https://brakemanscanner.org/docs/warning_types/<br />**Location**: app/controllers/password_resets_controller.rb:6<br />"
       expected_pr_comment_body = {
-        :body => "⚠️ **Potential Vulnerability Detected Outside Of PR** ⚠️<br /><br />You might not need to deal with this, but be aware that it exists in the codebase.<br />**Confidence level**: Medium<br />**Type**: Deserialize<br />**Description**: `Marshal.load` called with parameter value<br />**More information available at**: https://brakemanscanner.org/docs/warning_types/<br />**Location**: app/controllers/password_resets_controller.rb:6<br />"
+        body: "⚠️ **Potential Vulnerability Detected Outside Of PR** ⚠️<br /><br />You might not need to deal with this, but be aware that it exists in the codebase.<br />**Confidence level**: Medium<br />**Type**: Deserialize<br />**Description**: `Marshal.load` called with parameter value<br />**More information available at**: https://brakemanscanner.org/docs/warning_types/<br />**Location**: app/controllers/password_resets_controller.rb:6<br />"
       }
       expected_file_comment_body = {
         "annotation_level" => "warning",
@@ -84,15 +83,16 @@ describe GithubCheckRunService do
         to_return(status: 200, body: '{"id": "id"}')
 
       stub_request(:any, "https://api.github.com/repos/owner/repository_name/pulls/10/comments").
-          to_return(status: 422, body: '{"message":"Validation Failed","errors":[{"resource":"PullRequestReviewComment","code":"invalid","field":"pull_request_review_thread.path"},{"resource":"PullRequestReviewComment","code":"missing_field","field":"pull_request_review_thread.diff_hunk"}],"documentation_url":"https://docs.github.com/rest"}').
-          times(1)
+        to_return(status: 422, body: '{"message":"Validation Failed","errors":[{"resource":"PullRequestReviewComment","code":"invalid","field":"pull_request_review_thread.path"},{"resource":"PullRequestReviewComment","code":"missing_field","field":"pull_request_review_thread.diff_hunk"}],"documentation_url":"https://docs.github.com/rest"}').
+        times(1)
 
       stub_request(:post, "https://api.github.com/repos/owner/repository_name/pulls/10/comments").
-                  with(expected_pr_comment_body).
-                  to_return(status: 200, body: '{"id": "id"}').
-                  times(1)
+        with(expected_pr_comment_body).
+        to_return(status: 200, body: '{"id": "id"}').
+        times(1)
 
-      expect(service).to receive(:client_post_pull_request_for_issue_outside_of_pr).with(expected_file_comment_body).once
+      expect(service).to receive(:client_post_pull_request_for_issue_outside_of_pr).with(expected_file_comment_body).once.
+        and_return(expected_pr_comment_body)
       expect { service.run }.not_to raise_error
     end
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
bug fix

## Description
Posts a comment with a brakeman issue outside the PR rather than erroring.

Fixes #3  (issue)

## Why should this be added

Makes working with the action a lot easier!

## Checklist

- [x] Actions are passing
