### PR TITLE
Call GitHub API to complete the check

### DIFF
--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -23,7 +23,7 @@ class GithubCheckRunService
 
     result = {}
     if @annotations.empty?
-      result
+      client_patch_annotations(id, [])
     else
       @annotations.each_slice(MAX_ANNOTATIONS_SIZE) do |annotation|
         result.merge(client_patch_annotations(id, annotation))


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description

The main change introduced in #4 is to call GitHub API to mark check run complete even when Brakeman runs without any issues.

However, this change was removed (I guess accidentally?) in f8ae251351b33d9e0a5a2ccad761566d3c335871

@bermannoah if this is not accidental, please let me know your feedbacks and I'll make further changes. Thank you!

## Why should this be added

To complete GitHub check runs properly.

## Checklist

- [x] Actions are passing
